### PR TITLE
README.mdのダウンロードスクリプトURLを修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Cursor Rules は、コードベースに関する特定のルールやガイド�
 このリポジトリに含まれるダウンロードスクリプトを使用すると、簡単にルールやテンプレートをダウンロードできます：
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/nimiusrd/cursor-rules/main/install-cursor-rules.sh | bash
+curl -fsSL https://raw.githubusercontent.com/nimiusrd/cursor-rules/main/download-cursor-rules.sh | bash
 ```
 
 ### オプション


### PR DESCRIPTION
## 概要
README.md内のダウンロードスクリプトのURLを誤った「install-cursor-rules.sh」から正しい「download-cursor-rules.sh」に修正しました。これにより、ユーザーが正しいスクリプトファイルを参照できるようになります。

## 変更内容
- README.md内のダウンロードスクリプトURLを「install-cursor-rules.sh」から「download-cursor-rules.sh」に修正

## 影響範囲
- READMEドキュメント
- ユーザーのダウンロード手順

## 参考情報
- 以前は誤った「install-cursor-rules.sh」という名前を参照していましたが、実際のスクリプト名は「download-cursor-rules.sh」です
- この修正により、ドキュメントと実際のファイル名の一貫性が保たれます